### PR TITLE
12 upgrade to go 18 replace interface with any

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up GoLang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Check code standards
         run: test -z $(gofmt -l .)
@@ -29,7 +29,7 @@ jobs:
       - name: Set up GoLang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Look for suspicious code
         run: go vet
@@ -42,7 +42,7 @@ jobs:
       - name: Set up GoLang
         uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.18
 
       - name: Run unit tests
         run: go test -race -coverprofile=c.out ./...

--- a/context_test.go
+++ b/context_test.go
@@ -27,15 +27,15 @@ type newPathFinder struct{}
 
 type newFormatter struct{}
 
-func (n newFormatter) Deserialize(data []byte, v interface{}) error {
+func (n newFormatter) Deserialize(data []byte, v any) error {
 	panic("implement me")
 }
 
-func (n newFormatter) Serialize(v interface{}) ([]byte, error) {
+func (n newFormatter) Serialize(v any) ([]byte, error) {
 	panic("implement me")
 }
 
-func (n newPathFinder) Find(expr string, bytes []byte) (interface{}, error) {
+func (n newPathFinder) Find(expr string, bytes []byte) (any, error) {
 	panic("implement me")
 }
 
@@ -43,7 +43,7 @@ func (n newStringValidator) Validate(document, schemaPath string) error {
 	panic("implement me")
 }
 
-func (n newTemplateEngine) Replace(templateValue string, storage map[string]interface{}) (string, error) {
+func (n newTemplateEngine) Replace(templateValue string, storage map[string]any) (string, error) {
 	panic("implement me")
 }
 
@@ -51,11 +51,11 @@ func (n newClient) Do(req *http.Request) (*http.Response, error) {
 	panic("implement me")
 }
 
-func (n newCache) Save(key string, value interface{}) {
+func (n newCache) Save(key string, value any) {
 	panic("implement me")
 }
 
-func (n newCache) GetSaved(key string) (interface{}, error) {
+func (n newCache) GetSaved(key string) (any, error) {
 	panic("implement me")
 }
 
@@ -63,7 +63,7 @@ func (n newCache) Reset() {
 	panic("implement me")
 }
 
-func (n newCache) All() map[string]interface{} {
+func (n newCache) All() map[string]any {
 	panic("implement me")
 }
 
@@ -97,7 +97,7 @@ func TestState_ResetState(t *testing.T) {
 		t.Errorf("IsDebug property did not change")
 	}
 
-	if !reflect.DeepEqual(s.Cache.All(), map[string]interface{}{}) {
+	if !reflect.DeepEqual(s.Cache.All(), map[string]any{}) {
 		t.Errorf("cache did not reset")
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -1,24 +1,35 @@
 module github.com/pawelWritesCode/gdutils
 
-go 1.16
+go 1.18
 
 require (
-	github.com/antchfx/xmlquery v1.3.9 // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/fatih/color v1.13.0 // indirect
-	github.com/goccy/go-yaml v1.9.5 // indirect
-	github.com/kr/text v0.2.0 // indirect
-	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/antchfx/xmlquery v1.3.9
+	github.com/goccy/go-yaml v1.9.5
 	github.com/moul/http2curl v1.0.0
 	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852
 	github.com/pawelWritesCode/qjson v1.0.1
+	github.com/stretchr/testify v1.7.0
+	github.com/xeipuuv/gojsonschema v1.2.0
+	gopkg.in/yaml.v2 v2.4.0
+)
+
+require (
+	github.com/antchfx/xpath v1.2.0 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fatih/color v1.13.0 // indirect
+	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
+	github.com/kr/text v0.2.0 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/stretchr/objx v0.1.1 // indirect
-	github.com/stretchr/testify v1.7.0
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
-	github.com/xeipuuv/gojsonschema v1.2.0
+	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
+	golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc // indirect
 	golang.org/x/sys v0.0.0-20220224120231-95c6836cb0e7 // indirect
+	golang.org/x/text v0.3.2 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,11 @@ github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGE
 github.com/fatih/color v1.13.0 h1:8LOYc1KYPPmyKMuN8QV2DNRWNbLo6LZ0iLs8+mlH53w=
 github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
+github.com/go-playground/locales v0.13.0 h1:HyWk6mgj5qFqCT5fjGBuRArbVDfE4hi8+e8ceBS/t7Q=
 github.com/go-playground/locales v0.13.0/go.mod h1:taPMhCMXrRLJO55olJkUXHZBHCxTMfnGwq/HNwmWNS8=
+github.com/go-playground/universal-translator v0.17.0 h1:icxd5fm+REJzpZx7ZfpaD876Lmtgy7VtROAbHHXk8no=
 github.com/go-playground/universal-translator v0.17.0/go.mod h1:UkSxE5sNxxRwHyU+Scu5vgOQjsIJAF8j9muTVoKLVtA=
+github.com/go-playground/validator/v10 v10.4.1 h1:pH2c5ADXtd66mxoE0Zm9SUhxE20r7aM3F26W0hOn+GE=
 github.com/go-playground/validator/v10 v10.4.1/go.mod h1:nlOn6nFhuKACm19sB/8EGNn9GlaMV7XkbRSipzJ0Ii4=
 github.com/goccy/go-yaml v1.9.5 h1:Eh/+3uk9kLxG4koCX6lRMAPS1OaMSAi+FJcya0INdB0=
 github.com/goccy/go-yaml v1.9.5/go.mod h1:U/jl18uSupI5rdI2jmuCswEA2htH9eXfferR3KfscvA=
@@ -27,6 +30,7 @@ github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
 github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
+github.com/leodido/go-urn v1.2.0 h1:hpXL4XnriNwQ/ABnpepYM/1vCLWNDfUNts8dX3xTG6Y=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
@@ -62,6 +66,7 @@ github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:
 github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -11,14 +11,14 @@ var ErrMissingKey = errors.New("missing key")
 // Cache is entity that has ability to store/retrieve arbitrary values.
 type Cache interface {
 	// Save preserve provided value under given key.
-	Save(key string, value interface{})
+	Save(key string, value any)
 
 	// GetSaved retrieve value from given key.
-	GetSaved(key string) (interface{}, error)
+	GetSaved(key string) (any, error)
 
 	// Reset turns cache into init state - clears all entries.
 	Reset()
 
 	// All returns all cache entries.
-	All() map[string]interface{}
+	All() map[string]any
 }

--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -28,7 +28,7 @@ func TestDefaultCache_GetAllValues(t *testing.T) {
 	c.Save("test1", 1)
 	c.Save("test2", 2)
 
-	expected := map[string]interface{}{"test1": 1, "test2": 2}
+	expected := map[string]any{"test1": 1, "test2": 2}
 
 	if !reflect.DeepEqual(c.All(), expected) {
 		t.Errorf("all does not returns all cached values")
@@ -40,7 +40,7 @@ func TestDefaultCache_Reset(t *testing.T) {
 	c.Save("test1", 1)
 	c.Save("test2", 2)
 
-	expected := map[string]interface{}{"test1": 1, "test2": 2}
+	expected := map[string]any{"test1": 1, "test2": 2}
 
 	if !reflect.DeepEqual(c.All(), expected) {
 		t.Errorf("all does not returns all cached values")
@@ -48,7 +48,7 @@ func TestDefaultCache_Reset(t *testing.T) {
 
 	c.Reset()
 
-	if !reflect.DeepEqual(c.All(), map[string]interface{}{}) {
+	if !reflect.DeepEqual(c.All(), map[string]any{}) {
 		t.Errorf("reset does not work")
 	}
 }
@@ -58,7 +58,7 @@ func TestConcurrentCache_Reset(t *testing.T) {
 	c.Save("test1", 1)
 	c.Save("test2", 2)
 
-	expected := map[string]interface{}{"test1": 1, "test2": 2}
+	expected := map[string]any{"test1": 1, "test2": 2}
 
 	if !reflect.DeepEqual(c.All(), expected) {
 		t.Errorf("all does not returns all cached values")
@@ -66,7 +66,7 @@ func TestConcurrentCache_Reset(t *testing.T) {
 
 	c.Reset()
 
-	if !reflect.DeepEqual(c.All(), map[string]interface{}{}) {
+	if !reflect.DeepEqual(c.All(), map[string]any{}) {
 		t.Errorf("reset does not work")
 	}
 }
@@ -94,7 +94,7 @@ func TestConcurrentCache_GetAllValues(t *testing.T) {
 	c.Save("test1", 1)
 	c.Save("test2", 2)
 
-	expected := map[string]interface{}{"test1": 1, "test2": 2}
+	expected := map[string]any{"test1": 1, "test2": 2}
 
 	if !reflect.DeepEqual(c.All(), expected) {
 		t.Errorf("all does not returns all cached values")

--- a/pkg/cache/concurrent_cache.go
+++ b/pkg/cache/concurrent_cache.go
@@ -14,11 +14,11 @@ type ConcurrentCache struct {
 // NewConcurrentCache returns pointer to ConcurrentCache safe for concurrent use
 func NewConcurrentCache() *ConcurrentCache { return &ConcurrentCache{buff: sync.Map{}} }
 
-func (c *ConcurrentCache) Save(key string, value interface{}) {
+func (c *ConcurrentCache) Save(key string, value any) {
 	c.buff.Store(key, value)
 }
 
-func (c *ConcurrentCache) GetSaved(key string) (interface{}, error) {
+func (c *ConcurrentCache) GetSaved(key string) (any, error) {
 	val, ok := c.buff.Load(key)
 	if ok == false {
 		return val, fmt.Errorf("%w: %s", ErrMissingKey, key)
@@ -31,9 +31,9 @@ func (c *ConcurrentCache) Reset() {
 	c.buff = sync.Map{}
 }
 
-func (c *ConcurrentCache) All() map[string]interface{} {
-	tmpMap := make(map[string]interface{})
-	c.buff.Range(func(key, value interface{}) bool {
+func (c *ConcurrentCache) All() map[string]any {
+	tmpMap := make(map[string]any)
+	c.buff.Range(func(key, value any) bool {
 		keyStr, ok := key.(string)
 		if !ok {
 			return true

--- a/pkg/cache/default_cache.go
+++ b/pkg/cache/default_cache.go
@@ -5,19 +5,19 @@ import "fmt"
 // DefaultCache is entity that has ability to store and retrieve arbitrary values.
 // Not safe for concurrent use.
 type DefaultCache struct {
-	buff map[string]interface{}
+	buff map[string]any
 }
 
 // NewDefaultCache returns pointer to DefaultCache not safe for concurrent use
-func NewDefaultCache() *DefaultCache { return &DefaultCache{buff: map[string]interface{}{}} }
+func NewDefaultCache() *DefaultCache { return &DefaultCache{buff: map[string]any{}} }
 
 // Save preserve value under given key in DefaultCache.
-func (c *DefaultCache) Save(key string, value interface{}) {
+func (c *DefaultCache) Save(key string, value any) {
 	c.buff[key] = value
 }
 
 // GetSaved returns preserved value if present, error otherwise.
-func (c *DefaultCache) GetSaved(key string) (interface{}, error) {
+func (c *DefaultCache) GetSaved(key string) (any, error) {
 	val, ok := c.buff[key]
 
 	if ok == false {
@@ -29,10 +29,10 @@ func (c *DefaultCache) GetSaved(key string) (interface{}, error) {
 
 // Reset turns cache into initial state - - clears all entries.
 func (c *DefaultCache) Reset() {
-	c.buff = map[string]interface{}{}
+	c.buff = map[string]any{}
 }
 
 // All returns all current cache data.
-func (c *DefaultCache) All() map[string]interface{} {
+func (c *DefaultCache) All() map[string]any {
 	return c.buff
 }

--- a/pkg/format/format.go
+++ b/pkg/format/format.go
@@ -50,13 +50,13 @@ func IsYAML(b []byte) bool {
 		return false
 	}
 
-	var y interface{}
+	var y any
 	return yaml.UnmarshalWithOptions(b, &y, yaml.Strict()) == nil
 }
 
 // IsXML checks whether bytes are in XML format.
 func IsXML(b []byte) bool {
-	var v interface{}
+	var v any
 	err := xml.Unmarshal(b, &v)
 	return err == nil
 }

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -12,10 +12,10 @@ import (
 // Formatter describes ability to serialize and deserialize data
 type Formatter interface {
 	// Deserialize deserializes data on v
-	Deserialize(data []byte, v interface{}) error
+	Deserialize(data []byte, v any) error
 
 	// Serialize serializes v
-	Serialize(v interface{}) ([]byte, error)
+	Serialize(v any) ([]byte, error)
 }
 
 // JSONFormatter is entity that has ability to work with JSON format
@@ -50,17 +50,17 @@ func NewAwareFormatter(JSONFormatter JSONFormatter, YAMLFormatter YAMLFormatter)
 }
 
 // Deserialize data in format of JSON on v
-func (J JSONFormatter) Deserialize(data []byte, v interface{}) error {
+func (J JSONFormatter) Deserialize(data []byte, v any) error {
 	return json.Unmarshal(data, v)
 }
 
 // Serialize serializes v into JSON format.
-func (J JSONFormatter) Serialize(v interface{}) ([]byte, error) {
+func (J JSONFormatter) Serialize(v any) ([]byte, error) {
 	return json.Marshal(v)
 }
 
 // Deserialize data in format of YAML on v
-func (Y YAMLFormatter) Deserialize(data []byte, v interface{}) error {
+func (Y YAMLFormatter) Deserialize(data []byte, v any) error {
 	if data == nil {
 		return errors.New("data should not be nil")
 	}
@@ -77,12 +77,12 @@ func (Y YAMLFormatter) Deserialize(data []byte, v interface{}) error {
 }
 
 // Serialize serializes v into YAML format.
-func (y YAMLFormatter) Serialize(v interface{}) ([]byte, error) {
+func (y YAMLFormatter) Serialize(v any) ([]byte, error) {
 	return yaml.Marshal(v)
 }
 
 // Deserialize data in format of JSON or YAML on v
-func (a AwareFormatter) Deserialize(data []byte, v interface{}) error {
+func (a AwareFormatter) Deserialize(data []byte, v any) error {
 	if err := a.JSONFormatter.Deserialize(data, v); err == nil {
 		return nil
 	}
@@ -95,7 +95,7 @@ func (a AwareFormatter) Deserialize(data []byte, v interface{}) error {
 }
 
 // Deserialize data in format of XML on v.
-func (X XMLFormatter) Deserialize(data []byte, v interface{}) error {
+func (X XMLFormatter) Deserialize(data []byte, v any) error {
 	if data == nil {
 		return errors.New("data should not be nil")
 	}
@@ -108,6 +108,6 @@ func (X XMLFormatter) Deserialize(data []byte, v interface{}) error {
 }
 
 // Serialize serializes v into XML format.
-func (X XMLFormatter) Serialize(v interface{}) ([]byte, error) {
+func (X XMLFormatter) Serialize(v any) ([]byte, error) {
 	return xml.Marshal(v)
 }

--- a/pkg/formatter/formatter_test.go
+++ b/pkg/formatter/formatter_test.go
@@ -7,7 +7,7 @@ import (
 
 type bodyHeaders struct {
 	// Body should contain HTTP(s) request body
-	Body interface{} `xml:"body" yaml:"body"`
+	Body any `xml:"body" yaml:"body"`
 
 	// Headers should contain HTTP(s) request headers
 	Headers map[string]string `xml:"headers" yaml:"headers"`
@@ -18,7 +18,7 @@ type cookiesSlice []http.Cookie
 func TestJSONFormatter_Deserialize(t *testing.T) {
 
 	type fields struct {
-		v interface{}
+		v any
 	}
 	type args struct {
 		data []byte
@@ -74,7 +74,7 @@ func TestJSONFormatter_Deserialize(t *testing.T) {
 func TestYAMLFormatter_Deserialize(t *testing.T) {
 	type args struct {
 		data []byte
-		v    interface{}
+		v    any
 	}
 	tests := []struct {
 		name    string

--- a/pkg/httpctx/validator.go
+++ b/pkg/httpctx/validator.go
@@ -11,7 +11,7 @@ type URLValidator struct{}
 func NewURLValidator() URLValidator { return URLValidator{} }
 
 // Validate checks whether in is valid URL
-func (U URLValidator) Validate(in interface{}) error {
+func (U URLValidator) Validate(in any) error {
 	source, ok := in.(string)
 	if !ok {
 		return fmt.Errorf("+%v is not string", in)

--- a/pkg/httpctx/validator_test.go
+++ b/pkg/httpctx/validator_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestURLValidator_Validate(t *testing.T) {
 	type args struct {
-		in interface{}
+		in any
 	}
 	tests := []struct {
 		name    string

--- a/pkg/osutils/osutils.go
+++ b/pkg/osutils/osutils.go
@@ -69,7 +69,7 @@ func NewOSFileRecognizer(prefix string, fileValidator v.Validator) OSFileRecogni
 }
 
 // Validate checks whether in is valid path to any file on local user OS
-func (fv FileValidator) Validate(in interface{}) error {
+func (fv FileValidator) Validate(in any) error {
 	p, ok := in.(string)
 	if !ok {
 		return fmt.Errorf("%+v is not string", in)

--- a/pkg/osutils/osutils_test.go
+++ b/pkg/osutils/osutils_test.go
@@ -14,7 +14,7 @@ type mockedFileValidator struct {
 	mock.Mock
 }
 
-func (m *mockedFileValidator) Validate(in interface{}) error {
+func (m *mockedFileValidator) Validate(in any) error {
 	args := m.Called(in)
 
 	return args.Error(0)

--- a/pkg/pathfinder/jsonpath.go
+++ b/pkg/pathfinder/jsonpath.go
@@ -36,24 +36,24 @@ func NewDynamicJSONPathFinder(qjson QJSONFinder, oliveagleJSONFinder OliveagleJS
 }
 
 // Find obtains data from jsonBytes according to given expr valid with oliveagle/jsonpath library
-func (Q QJSONFinder) Find(expr string, jsonBytes []byte) (interface{}, error) {
+func (Q QJSONFinder) Find(expr string, jsonBytes []byte) (any, error) {
 	return qjson.Resolve(expr, jsonBytes)
 }
 
 // Find obtains data from jsonBytes according to given expr valid with pawelWritesCode/qjson library
-func (o OliveagleJSONFinder) Find(expr string, jsonBytes []byte) (interface{}, error) {
-	var jsonData interface{}
+func (o OliveagleJSONFinder) Find(expr string, jsonBytes []byte) (any, error) {
+	var jsonData any
 	err := json.Unmarshal(jsonBytes, &jsonData)
 	if err != nil {
 		return nil, err
 	}
 
-	return jsonpath.JsonPathLookup(interface{}(jsonData), expr)
+	return jsonpath.JsonPathLookup(any(jsonData), expr)
 }
 
 // Find obtains data from jsonBytes according to given expr.
 // It accepts expr in format acceptable by pawelWritesCode/qjson or oliveagle/jsonpath libraries.
-func (d DynamicJSONPathFinder) Find(expr string, jsonBytes []byte) (interface{}, error) {
+func (d DynamicJSONPathFinder) Find(expr string, jsonBytes []byte) (any, error) {
 	if len(expr) == 0 {
 		return nil, fmt.Errorf("json path can't be empty string")
 	}

--- a/pkg/pathfinder/jsonpath_test.go
+++ b/pkg/pathfinder/jsonpath_test.go
@@ -55,7 +55,7 @@ func TestQJSONFinder_Find(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{name: "no expression", args: args{
@@ -73,19 +73,19 @@ func TestQJSONFinder_Find(t *testing.T) {
 		{name: "successful fetch data #1", args: args{
 			expr:      "store.book[0].category",
 			jsonBytes: jsonBytes,
-		}, want: interface{}("reference"), wantErr: false},
+		}, want: any("reference"), wantErr: false},
 		{name: "successful fetch data #2", args: args{
 			expr:      "store.book[1].price",
 			jsonBytes: jsonBytes,
-		}, want: interface{}(float64(12.99)), wantErr: false},
+		}, want: any(float64(12.99)), wantErr: false},
 		{name: "successful fetch data #3", args: args{
 			expr:      "store.book[2].available",
 			jsonBytes: jsonBytes,
-		}, want: interface{}(true), wantErr: false},
+		}, want: any(true), wantErr: false},
 		{name: "successful fetch data #4", args: args{
 			expr:      "store.bicycle",
 			jsonBytes: jsonBytes,
-		}, want: interface{}(map[string]interface{}{"color": "red", "price": float64(19.95)}), wantErr: false},
+		}, want: any(map[string]any{"color": "red", "price": float64(19.95)}), wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -110,7 +110,7 @@ func TestOliveagleJSONFInder_Find(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{name: "no expression", args: args{
@@ -140,11 +140,11 @@ func TestOliveagleJSONFInder_Find(t *testing.T) {
 		{name: "successful fetch data #1", args: args{
 			expr:      "$.expensive",
 			jsonBytes: jsonBytes,
-		}, want: interface{}(float64(10)), wantErr: false},
+		}, want: any(float64(10)), wantErr: false},
 		{name: "successful fetch data #2", args: args{
 			expr:      "$.store.book[0].price",
 			jsonBytes: jsonBytes,
-		}, want: interface{}(8.95), wantErr: false},
+		}, want: any(8.95), wantErr: false},
 		{name: "successful fetch data #3", args: args{
 			expr:      "$.store.book[-1].isbn",
 			jsonBytes: jsonBytes,
@@ -152,11 +152,11 @@ func TestOliveagleJSONFInder_Find(t *testing.T) {
 		{name: "successful fetch data #4", args: args{
 			expr:      "$.store.bicycle",
 			jsonBytes: jsonBytes,
-		}, want: interface{}(map[string]interface{}{"color": "red", "price": float64(19.95)}), wantErr: false},
+		}, want: any(map[string]any{"color": "red", "price": float64(19.95)}), wantErr: false},
 		{name: "successful fetch data #4", args: args{
 			expr:      "$.store.book[?(@.price > 10)].title",
 			jsonBytes: jsonBytes,
-		}, want: []interface{}{"Sword of Honour", "The Lord of the Rings"}, wantErr: false},
+		}, want: []any{"Sword of Honour", "The Lord of the Rings"}, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -186,7 +186,7 @@ func TestDynamicJSONPathResolver_Resolve(t *testing.T) {
 		name    string
 		fields  fields
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{name: "no expression", args: args{
@@ -216,11 +216,11 @@ func TestDynamicJSONPathResolver_Resolve(t *testing.T) {
 		{name: "successful fetch data #1", args: args{
 			expr:      "$.expensive",
 			jsonBytes: jsonBytes,
-		}, want: interface{}(float64(10)), wantErr: false},
+		}, want: any(float64(10)), wantErr: false},
 		{name: "successful fetch data #2", args: args{
 			expr:      "$.store.book[0].price",
 			jsonBytes: jsonBytes,
-		}, want: interface{}(8.95), wantErr: false},
+		}, want: any(8.95), wantErr: false},
 		{name: "successful fetch data #3", args: args{
 			expr:      "$.store.book[-1].isbn",
 			jsonBytes: jsonBytes,
@@ -228,27 +228,27 @@ func TestDynamicJSONPathResolver_Resolve(t *testing.T) {
 		{name: "successful fetch data #4", args: args{
 			expr:      "$.store.bicycle",
 			jsonBytes: jsonBytes,
-		}, want: interface{}(map[string]interface{}{"color": "red", "price": float64(19.95)}), wantErr: false},
+		}, want: any(map[string]any{"color": "red", "price": float64(19.95)}), wantErr: false},
 		{name: "successful fetch data #4", args: args{
 			expr:      "$.store.book[?(@.price > 10)].title",
 			jsonBytes: jsonBytes,
-		}, want: []interface{}{"Sword of Honour", "The Lord of the Rings"}, wantErr: false},
+		}, want: []any{"Sword of Honour", "The Lord of the Rings"}, wantErr: false},
 		{name: "successful fetch data #1", args: args{
 			expr:      "store.book[0].category",
 			jsonBytes: jsonBytes,
-		}, want: interface{}("reference"), wantErr: false},
+		}, want: any("reference"), wantErr: false},
 		{name: "successful fetch data #2", args: args{
 			expr:      "store.book[1].price",
 			jsonBytes: jsonBytes,
-		}, want: interface{}(float64(12.99)), wantErr: false},
+		}, want: any(float64(12.99)), wantErr: false},
 		{name: "successful fetch data #3", args: args{
 			expr:      "store.book[2].available",
 			jsonBytes: jsonBytes,
-		}, want: interface{}(true), wantErr: false},
+		}, want: any(true), wantErr: false},
 		{name: "successful fetch data #4", args: args{
 			expr:      "store.bicycle",
 			jsonBytes: jsonBytes,
-		}, want: interface{}(map[string]interface{}{"color": "red", "price": float64(19.95)}), wantErr: false},
+		}, want: any(map[string]any{"color": "red", "price": float64(19.95)}), wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/pathfinder/pathfinder.go
+++ b/pkg/pathfinder/pathfinder.go
@@ -5,5 +5,5 @@ package pathfinder
 type PathFinder interface {
 
 	// Find obtains data from bytes according to given expression
-	Find(expr string, bytes []byte) (interface{}, error)
+	Find(expr string, bytes []byte) (any, error)
 }

--- a/pkg/pathfinder/xmlpath.go
+++ b/pkg/pathfinder/xmlpath.go
@@ -14,7 +14,7 @@ func NewAntchfxXMLFinder() AntchfxXMLFinder {
 	return AntchfxXMLFinder{}
 }
 
-func (a AntchfxXMLFinder) Find(expr string, bytes []byte) (interface{}, error) {
+func (a AntchfxXMLFinder) Find(expr string, bytes []byte) (any, error) {
 	parser, err := xmlquery.Parse(bytes2.NewReader(bytes))
 	if err != nil {
 		return nil, err
@@ -26,11 +26,11 @@ func (a AntchfxXMLFinder) Find(expr string, bytes []byte) (interface{}, error) {
 	}
 
 	if len(nodes) == 1 {
-		return interface{}(nodes[0].InnerText()), nil
+		return any(nodes[0].InnerText()), nil
 	}
 
 	if len(nodes) > 1 {
-		results := make([]interface{}, 0, len(nodes))
+		results := make([]any, 0, len(nodes))
 		for _, node := range nodes {
 			results = append(results, node.InnerText())
 		}

--- a/pkg/pathfinder/xmlpath_test.go
+++ b/pkg/pathfinder/xmlpath_test.go
@@ -135,25 +135,25 @@ func TestAntchfxXMLFinder_Find(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{name: "first book author", args: args{
 			expr:  "//book[1]//author",
 			bytes: s,
-		}, want: interface{}("Gambardella, Matthew"), wantErr: false},
+		}, want: any("Gambardella, Matthew"), wantErr: false},
 		{name: "book of id bk104", args: args{
 			expr:  "//book[@id='bk104']",
 			bytes: s,
-		}, want: interface{}("\n      Corets, Eva\n      Oberon's Legacy\n      Fantasy\n      5.95\n      2001-03-10\n      In post-apocalypse England, the mysterious \n      agent known only as Oberon helps to create a new life \n      for the inhabitants of London. Sequel to Maeve \n      Ascendant.\n   "), wantErr: false},
+		}, want: any("\n      Corets, Eva\n      Oberon's Legacy\n      Fantasy\n      5.95\n      2001-03-10\n      In post-apocalypse England, the mysterious \n      agent known only as Oberon helps to create a new life \n      for the inhabitants of London. Sequel to Maeve \n      Ascendant.\n   "), wantErr: false},
 		{name: "all titles of books cheaper than 5", args: args{
 			expr:  "//book[price<5]//title",
 			bytes: s,
-		}, want: []interface{}{"Lover Birds", "Splish Splash", "Creepy Crawlies"}, wantErr: false},
+		}, want: []any{"Lover Birds", "Splish Splash", "Creepy Crawlies"}, wantErr: false},
 		{name: "all book authors", args: args{
 			expr:  "//book//author",
 			bytes: s,
-		}, want: []interface{}{"Gambardella, Matthew", "Ralls, Kim", "Corets, Eva", "Corets, Eva", "Corets, Eva", "Randall, Cynthia", "Thurman, Paula", "Knorr, Stefan", "Kress, Peter", "O'Brien, Tim", "O'Brien, Tim", "Galos, Mike"}, wantErr: false},
+		}, want: []any{"Gambardella, Matthew", "Ralls, Kim", "Corets, Eva", "Corets, Eva", "Corets, Eva", "Randall, Cynthia", "Thurman, Paula", "Knorr, Stefan", "Kress, Peter", "O'Brien, Tim", "O'Brien, Tim", "Galos, Mike"}, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/pathfinder/yamlpath.go
+++ b/pkg/pathfinder/yamlpath.go
@@ -12,13 +12,13 @@ func NewGoccyGoYamlFinder() GoccyGoYamlFinder {
 	return GoccyGoYamlFinder{}
 }
 
-func (g GoccyGoYamlFinder) Find(expr string, jsonBytes []byte) (interface{}, error) {
+func (g GoccyGoYamlFinder) Find(expr string, jsonBytes []byte) (any, error) {
 	yamlPath, err := yaml.PathString(expr)
 	if err != nil {
 		return nil, err
 	}
 
-	var result interface{}
+	var result any
 	err = yamlPath.Read(bytes.NewReader(jsonBytes), &result)
 	if err != nil {
 		return nil, err

--- a/pkg/pathfinder/yamlpath_test.go
+++ b/pkg/pathfinder/yamlpath_test.go
@@ -25,7 +25,7 @@ func TestGoccyGoYamlFinder_Find(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    interface{}
+		want    any
 		wantErr bool
 	}{
 		{name: "no expression", args: args{
@@ -43,19 +43,19 @@ func TestGoccyGoYamlFinder_Find(t *testing.T) {
 		{name: "successful fetch data #1", args: args{
 			expr:      "$.store.book[0].author",
 			yamlBytes: []byte(yml),
-		}, want: interface{}("john"), wantErr: false},
+		}, want: any("john"), wantErr: false},
 		{name: "successful fetch data #2", args: args{
 			expr:      "$.store.book[0].price",
 			yamlBytes: []byte(yml),
-		}, want: interface{}(uint64(10)), wantErr: false},
+		}, want: any(uint64(10)), wantErr: false},
 		{name: "successful fetch data #2", args: args{
 			expr:      "$.store.bicycle.color",
 			yamlBytes: []byte(yml),
-		}, want: interface{}("red"), wantErr: false},
+		}, want: any("red"), wantErr: false},
 		{name: "successful fetch data #2", args: args{
 			expr:      "$.store.book",
 			yamlBytes: []byte(yml),
-		}, want: []interface{}{map[string]interface{}{"author": "john", "price": uint64(10)}, map[string]interface{}{"author": "ken", "price": uint64(12)}}, wantErr: false},
+		}, want: []any{map[string]any{"author": "john", "price": uint64(10)}, map[string]any{"author": "ken", "price": uint64(12)}}, wantErr: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/schema/validator_test.go
+++ b/pkg/schema/validator_test.go
@@ -17,13 +17,13 @@ type mockedUrlValidator struct {
 	mock.Mock
 }
 
-func (m *mockedFileValidator) Validate(in interface{}) error {
+func (m *mockedFileValidator) Validate(in any) error {
 	args := m.Called(in)
 
 	return args.Error(0)
 }
 
-func (m *mockedUrlValidator) Validate(in interface{}) error {
+func (m *mockedUrlValidator) Validate(in any) error {
 	args := m.Called(in)
 
 	return args.Error(0)

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -20,7 +20,7 @@ var (
 // Engine is entity that has ability to work with templates.
 type Engine interface {
 	// Replace replaces template values using provided storage.
-	Replace(templateValue string, storage map[string]interface{}) (string, error)
+	Replace(templateValue string, storage map[string]any) (string, error)
 }
 
 // TemplateManager is entity that has ability to manage templates.
@@ -32,7 +32,7 @@ func New() TemplateManager {
 
 // Replace replaces template values using provided storage.
 // templateValue should exist between two brackets {{ }} preceded with dot, for example: "my name is: {{.NAME}}".
-func (tm TemplateManager) Replace(templateValue string, storage map[string]interface{}) (string, error) {
+func (tm TemplateManager) Replace(templateValue string, storage map[string]any) (string, error) {
 	if storage == nil {
 		return "", fmt.Errorf("%w: passed nil storage for TemplateManager, storage should not be nil", ErrMissingStorage)
 	}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -15,7 +15,7 @@ func TestTemplateManager_Replace(t *testing.T) {
 
 	type args struct {
 		templateValue string
-		storage       map[string]interface{}
+		storage       map[string]any
 	}
 	tests := []struct {
 		name    string
@@ -29,67 +29,67 @@ func TestTemplateManager_Replace(t *testing.T) {
 		}, want: "", wantErr: true},
 		{name: "simple string without template value #1", args: args{
 			templateValue: "abc",
-			storage:       map[string]interface{}{},
+			storage:       map[string]any{},
 		}, want: "abc", wantErr: false},
 		{name: "simple string without template value #2", args: args{
 			templateValue: "abc",
-			storage:       map[string]interface{}{"abc": "def"},
+			storage:       map[string]any{"abc": "def"},
 		}, want: "abc", wantErr: false},
 		{name: "simple string with missing template value in storage", args: args{
 			templateValue: "abc {{.NAME}}",
-			storage:       map[string]interface{}{},
+			storage:       map[string]any{},
 		}, want: "", wantErr: true},
 		{name: "simple string with template value #2", args: args{
 			templateValue: "abc {{.NAME}}",
-			storage:       map[string]interface{}{"NAME": "xyz"},
+			storage:       map[string]any{"NAME": "xyz"},
 		}, want: "abc xyz", wantErr: false},
 		{name: "missing at least one template value in storage #1", args: args{
 			templateValue: "abc {{.NAME}}",
-			storage:       map[string]interface{}{"OTHER": "xyz"},
+			storage:       map[string]any{"OTHER": "xyz"},
 		}, want: "", wantErr: true},
 		{name: "missing at least one template value in storage #2", args: args{
 			templateValue: "abc {{.NAME}} {{.LAST_NAME}}",
-			storage:       map[string]interface{}{"NAME": "xyz"},
+			storage:       map[string]any{"NAME": "xyz"},
 		}, want: "", wantErr: true},
 		{name: "multi template string #1", args: args{
 			templateValue: "abc {{.NAME}} {{.LAST_NAME}}",
-			storage:       map[string]interface{}{"NAME": "xyz", "LAST_NAME": "xxx"},
+			storage:       map[string]any{"NAME": "xyz", "LAST_NAME": "xxx"},
 		}, want: "abc xyz xxx", wantErr: false},
 		{name: "multi template string #1", args: args{
 			templateValue: "{{.NAME}} abc {{.LAST_NAME}}",
-			storage:       map[string]interface{}{"NAME": true, "LAST_NAME": 111},
+			storage:       map[string]any{"NAME": true, "LAST_NAME": 111},
 		}, want: "true abc 111", wantErr: false},
 		{name: "key with dot #1", args: args{
 			templateValue: "{{.RANDOM_USER.TOKEN}}",
-			storage:       map[string]interface{}{"RANDOM_USER": map[string]string{"TOKEN": "a.b.c"}},
+			storage:       map[string]any{"RANDOM_USER": map[string]string{"TOKEN": "a.b.c"}},
 		}, want: "a.b.c", wantErr: false},
 		{name: "key with dot #2", args: args{
 			templateValue: "{{.RANDOM_USER.TOKEN}}",
-			storage: map[string]interface{}{"RANDOM_USER": struct {
+			storage: map[string]any{"RANDOM_USER": struct {
 				TOKEN string
 			}{TOKEN: "a.b.c"}},
 		}, want: "a.b.c", wantErr: false},
 		{name: "key with dot #3", args: args{
 			templateValue: "{{.RANDOM_USER.Token}}",
-			storage: map[string]interface{}{"RANDOM_USER": struct {
+			storage: map[string]any{"RANDOM_USER": struct {
 				Token string
 			}{Token: "a.b.c"}},
 		}, want: "a.b.c", wantErr: false},
 		{name: "use function on template #1", args: args{
 			templateValue: `{{.TIME.Format "2006-01-02T15:04:05Z07:00"}}`,
-			storage:       map[string]interface{}{"TIME": tm},
+			storage:       map[string]any{"TIME": tm},
 		}, want: "2014-02-04T18:05:00Z", wantErr: false},
 		{name: "use function on template #2", args: args{
 			templateValue: `{{.TIME.Format "Jan 2, 2006 at 3:04pm (MST)"}}`,
-			storage:       map[string]interface{}{"TIME": tm},
+			storage:       map[string]any{"TIME": tm},
 		}, want: "Feb 4, 2014 at 6:05pm (PST)", wantErr: false},
 		{name: "use function on template #3", args: args{
 			templateValue: `{{.TIME.Format "2006-01-02"}}`,
-			storage:       map[string]interface{}{"TIME": tm},
+			storage:       map[string]any{"TIME": tm},
 		}, want: "2014-02-04", wantErr: false},
 		{name: "use function on template #4", args: args{
 			templateValue: `{{.TIME}}`,
-			storage:       map[string]interface{}{"TIME": tm},
+			storage:       map[string]any{"TIME": tm},
 		}, want: "2014-02-04 18:05:00 +0000 PST", wantErr: false},
 	}
 	for _, tt := range tests {

--- a/pkg/validator/validator.go
+++ b/pkg/validator/validator.go
@@ -10,5 +10,5 @@ type SchemaValidator interface {
 // Validator describes validator
 type Validator interface {
 	// Validate validates in
-	Validate(in interface{}) error
+	Validate(in any) error
 }

--- a/steps.go
+++ b/steps.go
@@ -37,7 +37,7 @@ import (
 type BodyHeaders struct {
 
 	// Body should contain HTTP(s) request body
-	Body interface{}
+	Body any
 
 	// Headers should contain HTTP(s) request headers
 	Headers map[string]string
@@ -632,7 +632,7 @@ func (apiCtx *APIContext) TheNodeShouldNotBe(dataFormat format.DataFormat, exprT
 		return fmt.Errorf("template engine has problem with 'form' template, err: %w", err)
 	}
 
-	var iNodeVal interface{}
+	var iNodeVal any
 	switch dataFormat {
 	case format.JSON:
 		iNodeVal, err = apiCtx.PathFinders.JSON.Find(expr, body)
@@ -731,7 +731,7 @@ func (apiCtx *APIContext) TheNodeShouldBeSliceOfLength(dataFormat format.DataFor
 		return fmt.Errorf("template engine has problem with 'expression' template, err: %w", err)
 	}
 
-	var iValue interface{}
+	var iValue any
 	switch dataFormat {
 	case format.JSON:
 		iValue, err = apiCtx.PathFinders.JSON.Find(expr, body)
@@ -790,7 +790,7 @@ func (apiCtx *APIContext) TheNodeShouldBeOfValue(dataFormat format.DataFormat, e
 		return fmt.Errorf("could not obtain last HTTP(s) response body, err: %w", err)
 	}
 
-	var iValue interface{}
+	var iValue any
 	switch dataFormat {
 	case format.JSON:
 		iValue, err = apiCtx.PathFinders.JSON.Find(expr, body)
@@ -915,7 +915,7 @@ func (apiCtx *APIContext) TheNodeShouldMatchRegExp(dataFormat format.DataFormat,
 		return fmt.Errorf("could not obtain last HTTP(s) response body, err: %w", err)
 	}
 
-	var iValue interface{}
+	var iValue any
 	switch dataFormat {
 	case format.JSON:
 		iValue, err = apiCtx.PathFinders.JSON.Find(expr, body)
@@ -1173,7 +1173,7 @@ func (apiCtx *APIContext) ISaveFromTheLastResponseNodeAs(dataFormat format.DataF
 		return fmt.Errorf("template engine has problem with 'expression' template, err: %w", err)
 	}
 
-	var iVal interface{}
+	var iVal any
 	switch dataFormat {
 	case format.JSON:
 		iVal, err = apiCtx.PathFinders.JSON.Find(expr, body)
@@ -1208,7 +1208,7 @@ func (apiCtx *APIContext) IWait(timeInterval time.Duration) error {
 
 // IPrintLastResponseBody prints last response from request.
 func (apiCtx *APIContext) IPrintLastResponseBody() error {
-	var tmp interface{}
+	var tmp any
 
 	body, err := apiCtx.GetLastResponseBody()
 	if err != nil {
@@ -1359,7 +1359,7 @@ func (apiCtx *APIContext) iValidateNodeWithSchemaGeneral(dataFormat format.DataF
 		return fmt.Errorf("template engine has problem with 'expression' template, err: %w", err)
 	}
 
-	var node interface{}
+	var node any
 	switch dataFormat {
 	case format.JSON:
 		node, err = apiCtx.PathFinders.JSON.Find(expr, body)

--- a/steps_test.go
+++ b/steps_test.go
@@ -39,13 +39,13 @@ type mockedFormatter struct {
 	mock.Mock
 }
 
-func (m *mockedFormatter) Deserialize(data []byte, v interface{}) error {
+func (m *mockedFormatter) Deserialize(data []byte, v any) error {
 	args := m.Called(data, v)
 
 	return args.Error(0)
 }
 
-func (m *mockedFormatter) Serialize(v interface{}) ([]byte, error) {
+func (m *mockedFormatter) Serialize(v any) ([]byte, error) {
 	args := m.Called(v)
 
 	return args.Get(0).([]byte), args.Error(1)
@@ -55,7 +55,7 @@ type mockedJsonPathFinder struct {
 	mock.Mock
 }
 
-func (m *mockedTemplateEngine) Replace(templateValue string, storage map[string]interface{}) (string, error) {
+func (m *mockedTemplateEngine) Replace(templateValue string, storage map[string]any) (string, error) {
 	args := m.Called(templateValue, storage)
 
 	return args.String(0), args.Error(1)
@@ -85,10 +85,10 @@ func (m *mockedHTTPContext) GetLastResponseBody() ([]byte, error) {
 	return args.Get(0).([]byte), args.Error(1)
 }
 
-func (m *mockedJsonPathFinder) Find(expr string, jsonBytes []byte) (interface{}, error) {
+func (m *mockedJsonPathFinder) Find(expr string, jsonBytes []byte) (any, error) {
 	args := m.Called(expr, jsonBytes)
 
-	return args.Get(0).(interface{}), args.Error(1)
+	return args.Get(0).(any), args.Error(1)
 }
 
 func TestState_IPrepareNewRequestToAndSaveItAs(t *testing.T) {
@@ -380,7 +380,7 @@ func TestState_ISetFollowingCookiesForPreparedRequest(t *testing.T) {
 
 func TestState_TheResponseStatusCodeShouldBe(t *testing.T) {
 	type fields struct {
-		cache        map[string]interface{}
+		cache        map[string]any
 		lastResponse *http.Response
 		isDebug      bool
 	}
@@ -718,7 +718,7 @@ users:
 
 	type fields struct {
 		body      []byte
-		cacheData map[string]interface{}
+		cacheData map[string]any
 	}
 	type args struct {
 		dataFormat  format.DataFormat
@@ -748,7 +748,7 @@ users:
 			dataFormat:  format.JSON,
 			expressions: "users[1].name",
 		}, wantErr: false},
-		{name: "last response body has expected key #4 - qjson expression with template value", fields: fields{body: []byte(json), cacheData: map[string]interface{}{
+		{name: "last response body has expected key #4 - qjson expression with template value", fields: fields{body: []byte(json), cacheData: map[string]any{
 			"USER_ID": 1,
 		}}, args: args{
 			dataFormat:  format.JSON,
@@ -772,7 +772,7 @@ users:
 			dataFormat:  format.XML,
 			expressions: "//user[2]//name",
 		}, wantErr: false},
-		{name: "last response body has expected key #4 - Antchfx expression with template value", fields: fields{body: []byte(xml), cacheData: map[string]interface{}{
+		{name: "last response body has expected key #4 - Antchfx expression with template value", fields: fields{body: []byte(xml), cacheData: map[string]any{
 			"USER_ID": 2,
 		}}, args: args{
 			dataFormat:  format.XML,
@@ -792,7 +792,7 @@ users:
 			dataFormat:  format.YAML,
 			expressions: "$.users[0].name",
 		}, wantErr: false},
-		{name: "last response body has expected key #3 - Goccy expression with template value", fields: fields{body: []byte(yaml), cacheData: map[string]interface{}{
+		{name: "last response body has expected key #3 - Goccy expression with template value", fields: fields{body: []byte(yaml), cacheData: map[string]any{
 			"USER_ID": 0,
 		}}, args: args{
 			dataFormat:  format.YAML,
@@ -846,7 +846,7 @@ users:
 
 	type fields struct {
 		body      []byte
-		cacheKeys map[string]interface{}
+		cacheKeys map[string]any
 	}
 	type args struct {
 		dataFormat  format.DataFormat
@@ -880,7 +880,7 @@ users:
 			dataFormat:  format.JSON,
 			expressions: "users[0].name, users[1].name",
 		}, wantErr: false},
-		{name: "last response body has expected keys #1 - qjson expressions with template values", fields: fields{body: []byte(json), cacheKeys: map[string]interface{}{
+		{name: "last response body has expected keys #1 - qjson expressions with template values", fields: fields{body: []byte(json), cacheKeys: map[string]any{
 			"USER1_ID": 0,
 			"USER2_ID": 1,
 		}}, args: args{
@@ -909,7 +909,7 @@ users:
 			dataFormat:  format.XML,
 			expressions: "//user[1]//name, //user[2]//name",
 		}, wantErr: false},
-		{name: "last response body has expected keys #5 - Antchfx expressions with template values", fields: fields{body: []byte(xml), cacheKeys: map[string]interface{}{
+		{name: "last response body has expected keys #5 - Antchfx expressions with template values", fields: fields{body: []byte(xml), cacheKeys: map[string]any{
 			"USER1_ID": 1,
 			"USER2_ID": 2,
 		}}, args: args{
@@ -938,7 +938,7 @@ users:
 			dataFormat:  format.YAML,
 			expressions: "$.users[0].name, $.users[1].name",
 		}, wantErr: false},
-		{name: "last response body has expected keys #5 - Goccy expressions with template values", fields: fields{body: []byte(yaml), cacheKeys: map[string]interface{}{
+		{name: "last response body has expected keys #5 - Goccy expressions with template values", fields: fields{body: []byte(yaml), cacheKeys: map[string]any{
 			"USER1_ID": 0,
 			"USER2_ID": 1,
 		}}, args: args{
@@ -965,7 +965,7 @@ users:
 
 func TestState_TheNodeShouldNotBe(t *testing.T) {
 	type fields struct {
-		saved        map[string]interface{}
+		saved        map[string]any
 		lastResponse *http.Response
 		isDebug      bool
 	}
@@ -1249,7 +1249,7 @@ users:
 
 func TestState_TheNodeShouldBe(t *testing.T) {
 	type fields struct {
-		saved        map[string]interface{}
+		saved        map[string]any
 		lastResponse *http.Response
 		isDebug      bool
 	}
@@ -1920,7 +1920,7 @@ func TestState_TheNodeShouldMatchRegExp(t *testing.T) {
 	mJsonPathResolver := new(mockedJsonPathFinder)
 
 	type fields struct {
-		cacheKeys      map[string]interface{}
+		cacheKeys      map[string]any
 		templateEngine template.Engine
 		pathResolvers  PathFinders
 		respBody       string
@@ -1967,7 +1967,7 @@ func TestState_TheNodeShouldMatchRegExp(t *testing.T) {
 					Return("xxx", nil).Once()
 
 				mJsonPathResolver.On("Find", "xxx", []byte("")).
-					Return(interface{}(""), errors.New("err")).Once()
+					Return(any(""), errors.New("err")).Once()
 			},
 		}, args: args{
 			df:             format.JSON,
@@ -2066,7 +2066,7 @@ name: abcdef`,
 
 func TestState_TheResponseShouldHaveHeader(t *testing.T) {
 	type fields struct {
-		cache        map[string]interface{}
+		cache        map[string]any
 		lastResponse *http.Response
 	}
 	type args struct {
@@ -2111,7 +2111,7 @@ func TestState_TheResponseShouldHaveHeader(t *testing.T) {
 
 func TestState_TheResponseShouldHaveHeaderOfValue(t *testing.T) {
 	type fields struct {
-		cache        map[string]interface{}
+		cache        map[string]any
 		lastResponse *http.Response
 		isDebug      bool
 	}
@@ -2151,7 +2151,7 @@ func TestState_TheResponseShouldHaveHeaderOfValue(t *testing.T) {
 				"Content-Type":   {"application/json"},
 			},
 		},
-			cache: map[string]interface{}{"CONTENT_TYPE_JSON": "application/json"},
+			cache: map[string]any{"CONTENT_TYPE_JSON": "application/json"},
 		}, args: args{name: "Content-Type", value: "{{.CONTENT_TYPE_JSON}}"}, wantErr: false},
 	}
 	for _, tt := range tests {
@@ -2594,7 +2594,7 @@ func TestState_TheResponseShouldHaveCookie(t *testing.T) {
 
 func TestState_ISaveAs(t *testing.T) {
 	type fields struct {
-		cacheData map[string]interface{}
+		cacheData map[string]any
 	}
 	type args struct {
 		value    string
@@ -2624,7 +2624,7 @@ func TestState_ISaveAs(t *testing.T) {
 			cacheKey: "a",
 		}, wantErr: false, want: "a"},
 		{name: "template value", fields: fields{
-			cacheData: map[string]interface{}{
+			cacheData: map[string]any{
 				"FIRST_NAME": "ABC",
 				"LAST_NAME":  "XXX",
 			},
@@ -2633,7 +2633,7 @@ func TestState_ISaveAs(t *testing.T) {
 			cacheKey: "a",
 		}, wantErr: false, want: "ABC XXX"},
 		{name: "template value", fields: fields{
-			cacheData: map[string]interface{}{
+			cacheData: map[string]any{
 				"HEIGHT": 10,
 			},
 		}, args: args{


### PR DESCRIPTION
Updated minimal go version to 1.18

Replaced all occurences of `interface{}` to `any`

#12 